### PR TITLE
Stabilize deployment and runtime configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,36 @@
+# ABCP credentials
+ABCP_BASE_URL=https://abcp61741.public.api.abcp.ru/cp/garage/
+ABCP_USERLOGIN=
+ABCP_USERPSW=
+ABCP_LIMIT=500
+
+# Bitrix24 webhook credentials
+B24_WEBHOOK_URL=
+B24_DEAL_CATEGORY_ID_USERS=
+B24_DEAL_TITLE_PREFIX=ABCP Регистрация:
+UF_B24_DEAL_ABCP_USER_ID=
+
+# Optional mapping overrides (UF codes)
+#UF_B24_DEAL_GARAGE_ID=
+#UF_B24_DEAL_GARAGE_USER_ID=
+#UF_B24_DEAL_GARAGE_NAME=
+# ... см. abcp_b24_garage_sync/config.py
+
+# Storage and logging paths
+ABCP_B24_DATA_DIR=./data
+SQLITE_PATH=garage.s3db
+LOG_DIR=./logs
+LOG_FILE=service.log
+LOG_LEVEL=INFO
+
+# Networking
+REQUESTS_TIMEOUT=20
+REQUESTS_RETRIES=3
+REQUESTS_RETRY_BACKOFF=1.5
+RATE_LIMIT_SLEEP=0.2
+
+# Sync behaviour
+SYNC_OVERWRITE_DEFAULT=true
+SYNC_OVERWRITE_FIELDS={}
+SYNC_PAUSE_BETWEEN_USERS=0
+SYNC_PAUSE_BETWEEN_DEALS=0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ jobs:
           ssh ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "\
             set -e; \
             DEPLOY_PATH='${{ secrets.DEPLOY_PATH }}'; \
-            mkdir -p \"\$DEPLOY_PATH/data\" \"\$DEPLOY_PATH/current\"; \
+            mkdir -p \"\$DEPLOY_PATH/data\" \"\$DEPLOY_PATH/current\" \"\$DEPLOY_PATH/logs\"; \
             if [ ! -f \"\$DEPLOY_PATH/.env\" ]; then \
               if [ -f \"\$DEPLOY_PATH/current/.env.example\" ]; then \
                 cp \"\$DEPLOY_PATH/current/.env.example\" \"\$DEPLOY_PATH/.env\"; \
@@ -68,46 +68,8 @@ jobs:
                 echo '!!! Created empty .env (no .env.example in repo)'; \
               fi; \
             fi; \
+            ln -sf \"\$DEPLOY_PATH/.env\" \"\$DEPLOY_PATH/current/.env\"; \
             chown -R '${{ secrets.DEPLOY_USER }}':'${{ secrets.DEPLOY_USER }}' \"\$DEPLOY_PATH\" || true \
-          "
-
-      - name: Ensure bin/sync.sh exists and is executable
-        run: |
-          ssh ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "\
-            set -e; \
-            DEPLOY_PATH='${{ secrets.DEPLOY_PATH }}'; \
-            APP_DIR=\"\$DEPLOY_PATH/current\"; \
-            BIN_DIR=\"\$APP_DIR/bin\"; \
-            VENV_DIR=\"\$DEPLOY_PATH/venv\"; \
-            DB_DIR=\"\$DEPLOY_PATH/data\"; \
-            mkdir -p \"\$BIN_DIR\" \"\$DB_DIR\"; \
-            if [ ! -f \"\$BIN_DIR/sync.sh\" ]; then \
-              printf '%s\n' \
-                '#!/usr/bin/env bash' \
-                'set -euo pipefail' \
-                '' \
-                'APP_DIR=\"/opt/abcp-b24-garage-sync/current\"' \
-                'VENV_DIR=\"/opt/abcp-b24-garage-sync/venv\"' \
-                'DB_DIR=\"/opt/abcp-b24-garage-sync/data\"' \
-                '' \
-                'mkdir -p \"$DB_DIR\"' \
-                '' \
-                '# venv' \
-                'if [[ ! -d \"$VENV_DIR\" ]]; then' \
-                '  python3 -m venv \"$VENV_DIR\"' \
-                'fi' \
-                'source \"$VENV_DIR/bin/activate\"' \
-                'python -m ensurepip -U >/dev/null 2>&1 || true' \
-                'pip -q install --upgrade pip wheel' \
-                'pip -q install -r \"$APP_DIR/requirements.txt\"' \
-                '' \
-                'cd \"$APP_DIR\"' \
-                '' \
-                '# main.py подставляет дефолтный диапазон дат' \
-                'python3 -m abcp_b24_garage_sync.main' \
-                > \"\$BIN_DIR/sync.sh\"; \
-            fi; \
-            chmod +x \"\$BIN_DIR/sync.sh\" \
           "
 
       - name: Install deps + prime venv
@@ -137,11 +99,15 @@ jobs:
               '' \
               '[Service]' \
               'Type=oneshot' \
-              'User=root' \
-              'Group=root' \
+              'User=${{ secrets.DEPLOY_USER }}' \
+              'Group=${{ secrets.DEPLOY_USER }}' \
               'WorkingDirectory=/opt/abcp-b24-garage-sync/current' \
+              'EnvironmentFile=-/opt/abcp-b24-garage-sync/.env' \
               'Environment=PYTHONUNBUFFERED=1' \
-              'ExecStart=/opt/abcp-b24-garage-sync/current/bin/sync.sh' \
+              'Environment=ABCP_B24_ENV_FILE=/opt/abcp-b24-garage-sync/.env' \
+              'Environment=ABCP_B24_DATA_DIR=/opt/abcp-b24-garage-sync/data' \
+              'Environment=LOG_DIR=/opt/abcp-b24-garage-sync/logs' \
+              'ExecStart=/opt/abcp-b24-garage-sync/venv/bin/python -m abcp_b24_garage_sync' \
               'KillSignal=SIGINT' \
               'TimeoutStartSec=900' \
               'ReadOnlyPaths=/' \

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 venv/
 .env
 .env.*
+!.env.example
 logs/
 data/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,22 +1,50 @@
 
 # ABCP → Bitrix24 Garage Sync (Python)
 
-Сервис синхронизации данных «гаража» из ABCP в сделки Bitrix24.
+Сервис синхронизации данных «гаража» из ABCP в сделки Bitrix24. Приложение можно запускать разово или по расписанию через systemd.
 
-## Установка
+## Быстрый старт для разработки
+
 ```bash
 python -m venv .venv
-# Windows: .venv\Scripts\activate
-# Linux/macOS: . .venv/bin/activate
+source .venv/bin/activate            # Windows: .venv\Scripts\activate
 pip install -r requirements.txt
-cp .env.example .env
-```
-## Запуск
-```bash
-# как пакет
+cp .env.example .env                  # заполните креды ABCP/B24
+
+# однократный прогон (дату можно не указывать — main.py подставит 2024-01-01..2025-12-31)
 python -m abcp_b24_garage_sync --from 2020-01-01 --to 2025-12-31
-# или напрямую
-python abcp_b24_garage_sync/main.py --from 2020-01-01 --to 2025-12-31
 ```
-Режимы: `--only-store`, `--only-sync`, `--only-sync --user <id>`.
-Логи: в консоль и в `logs/service.log` (ротация, 7 файлов).
+
+Поддерживаются режимы `--only-store`, `--only-sync`, `--only-sync --user <ID>`.
+
+## Конфигурация окружения
+
+* `.env` можно размещать как в каталоге проекта (`current/.env`), так и на уровень выше (`/opt/abcp-b24-garage-sync/.env`). Первый найденный файл будет загружен автоматически. Путь можно явно указать через переменную `ABCP_B24_ENV_FILE`.
+* `ABCP_B24_DATA_DIR` определяет базовую директорию для базы и логов. По умолчанию — корень проекта. Любые относительные пути (например, `SQLITE_PATH`, `LOG_DIR`) интерпретируются относительно этого каталога.
+* Логи пишутся в консоль и файл (по умолчанию `logs/service.log`, ротация раз в сутки, хранится 7 файлов). Переопределяется переменными `LOG_DIR` и `LOG_FILE`.
+
+См. `.env.example` для подсказок по переменным.
+
+## Развёртывание на сервер (systemd + таймер)
+
+1. Скопируйте проект (rsync/git) в `/opt/abcp-b24-garage-sync/current` и создайте Python‑виртуальное окружение в `/opt/abcp-b24-garage-sync/venv`.
+2. Заполните `/opt/abcp-b24-garage-sync/.env` (можно создать из `.env.example`) и при необходимости выполните `ln -sf ../.env current/.env`.
+3. Установите systemd-юниты из `deploy/systemd/`:
+
+```bash
+sudo cp deploy/systemd/abcp-b24-garage-sync.service /etc/systemd/system/
+sudo cp deploy/systemd/abcp-b24-garage-sync.timer    /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now abcp-b24-garage-sync.timer
+```
+
+Сервис запускает `python -m abcp_b24_garage_sync` из виртуального окружения и ожидает, что зависимости уже установлены (`pip install -r requirements.txt`). Таймер по умолчанию — каждые 30 минут (`OnCalendar=*:0/30`).
+
+Для разового запуска:
+
+```bash
+sudo systemctl start abcp-b24-garage-sync.service
+journalctl -u abcp-b24-garage-sync.service -f
+```
+
+Логи также доступны в `${LOG_DIR:-<data_dir>/logs}/service.log`.

--- a/abcp_b24_garage_sync/log_setup.py
+++ b/abcp_b24_garage_sync/log_setup.py
@@ -1,12 +1,87 @@
 
-import os, sys, logging
+from __future__ import annotations
+
+import logging
+import os
+import sys
 from logging.handlers import TimedRotatingFileHandler
-def setup_logging():
-    os.makedirs("logs", exist_ok=True)
-    level = getattr(logging, os.getenv("LOG_LEVEL","INFO").upper(), logging.INFO)
-    fmt = logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+from pathlib import Path
+
+
+_CONFIGURED = False
+
+
+def _project_root() -> Path:
+    """Return the project root directory even if launched from a release symlink."""
+
+    env_value = os.getenv("ABCP_B24_PROJECT_ROOT")
+    if env_value:
+        try:
+            return Path(env_value).expanduser()
+        except Exception:
+            pass
+    return Path(__file__).resolve().parents[1]
+
+
+def _data_root() -> Path:
+    """Base directory for runtime artefacts (DB, logs)."""
+
+    env_value = os.getenv("ABCP_B24_DATA_DIR") or os.getenv("ABC_B24_DATA_DIR")
+    if env_value:
+        try:
+            return Path(env_value).expanduser()
+        except Exception:
+            pass
+    return _project_root()
+
+
+def _resolve_log_dir() -> Path:
+    """Resolve LOG_DIR env to an absolute directory and create it if needed."""
+
+    raw = os.getenv("LOG_DIR")
+    base = _data_root()
+
+    if raw:
+        candidate = Path(raw).expanduser()
+        if not candidate.is_absolute():
+            candidate = base / candidate
+    else:
+        candidate = base / "logs"
+
+    candidate.mkdir(parents=True, exist_ok=True)
+    return candidate
+
+
+def setup_logging() -> None:
+    """Configure console + rotating file logging only once per process."""
+
+    global _CONFIGURED
+    if _CONFIGURED:
+        return
+
+    level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+
+    formatter = logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+
+    log_dir = _resolve_log_dir()
+    log_file = os.getenv("LOG_FILE", "service.log")
+    log_path = log_dir / log_file
+
     root = logging.getLogger()
     root.setLevel(level)
-    sh = logging.StreamHandler(sys.stdout); sh.setFormatter(fmt); root.addHandler(sh)
-    fh = TimedRotatingFileHandler("logs/service.log", when="D", backupCount=7, encoding="utf-8")
-    fh.setFormatter(fmt); root.addHandler(fh)
+    root.handlers.clear()
+
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setFormatter(formatter)
+    root.addHandler(stream_handler)
+
+    file_handler = TimedRotatingFileHandler(
+        filename=str(log_path), when="D", backupCount=7, encoding="utf-8"
+    )
+    file_handler.setFormatter(formatter)
+    root.addHandler(file_handler)
+
+    root.debug("Logging configured: level=%s log_path=%s", level_name, log_path)
+
+    _CONFIGURED = True

--- a/deploy/remote_bootstrap.sh
+++ b/deploy/remote_bootstrap.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 APP_ROOT="/opt/abcp-b24-garage-sync"
 
+sudo install -d -m 755 -o "${USER}" -g "${USER}" "$APP_ROOT/data" "$APP_ROOT/logs"
+sudo ln -sf "$APP_ROOT/.env" "$APP_ROOT/current/.env" 2>/dev/null || true
+
 sudo cp "$APP_ROOT/current/deploy/systemd/abcp-b24-garage-sync.service" /etc/systemd/system/abcp-b24-garage-sync.service
 sudo cp "$APP_ROOT/current/deploy/systemd/abcp-b24-garage-sync.timer"    /etc/systemd/system/abcp-b24-garage-sync.timer
 

--- a/deploy/systemd/abcp-b24-garage-sync.service
+++ b/deploy/systemd/abcp-b24-garage-sync.service
@@ -8,8 +8,12 @@ Type=oneshot
 User=deploy
 Group=deploy
 WorkingDirectory=/opt/abcp-b24-garage-sync/current
+EnvironmentFile=-/opt/abcp-b24-garage-sync/.env
 Environment=PYTHONUNBUFFERED=1
-ExecStart=/opt/abcp-b24-garage-sync/current/bin/sync.sh
+Environment=ABCP_B24_ENV_FILE=/opt/abcp-b24-garage-sync/.env
+Environment=ABCP_B24_DATA_DIR=/opt/abcp-b24-garage-sync/data
+Environment=LOG_DIR=/opt/abcp-b24-garage-sync/logs
+ExecStart=/opt/abcp-b24-garage-sync/venv/bin/python -m abcp_b24_garage_sync
 # защита от убийства при перезапусках демонов
 KillSignal=SIGINT
 TimeoutStartSec=900

--- a/deploy/systemd/abcp-b24-garage-sync.timer
+++ b/deploy/systemd/abcp-b24-garage-sync.timer
@@ -2,7 +2,7 @@
 Description=Run ABCP -> Bitrix24 Garage Sync periodically
 
 [Timer]
-OnCalendar=*:0/30      # каждые 10 минут
+OnCalendar=*:0/30      # каждые 30 минут
 AccuracySec=1min
 Persistent=true        # если пропуск — запустит при старте
 

--- a/tests/test_infrastructure.py
+++ b/tests/test_infrastructure.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from abcp_b24_garage_sync import db
+from abcp_b24_garage_sync import main as cli_main
+
+
+class DbPathTests(unittest.TestCase):
+    def test_absolute_path_is_used_verbatim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            absolute = Path(tmp) / "db.sqlite"
+            resolved = db._resolve_db_path(str(absolute))
+            self.assertEqual(resolved, absolute)
+            self.assertTrue(resolved.parent.exists())
+
+    def test_relative_path_uses_data_dir_env(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            data_dir = Path(tmp) / "data"
+            with mock.patch.dict(os.environ, {"ABCP_B24_DATA_DIR": str(data_dir)}, clear=True):
+                resolved = db._resolve_db_path("storage/garage.sqlite")
+                self.assertTrue(resolved.is_absolute())
+                self.assertTrue(str(resolved).startswith(str(data_dir)))
+                self.assertEqual(resolved.name, "garage.sqlite")
+                self.assertTrue(resolved.parent.exists())
+
+    def test_relative_path_falls_back_to_project_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project_root = Path(tmp)
+            env = {
+                "ABCP_B24_PROJECT_ROOT": str(project_root),
+            }
+            with mock.patch.dict(os.environ, env, clear=True):
+                resolved = db._resolve_db_path("garage.sqlite")
+                self.assertEqual(resolved, project_root / "garage.sqlite")
+
+
+class DiscoverEnvFileTests(unittest.TestCase):
+    def test_prefers_explicit_override(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "current"
+            project.mkdir()
+            override = Path(tmp) / "custom.env"
+            override.write_text("TEST=1")
+            env = {"ABCP_B24_ENV_FILE": str(override)}
+            with mock.patch.dict(os.environ, env, clear=True):
+                discovered = cli_main._discover_env_file(project)
+            self.assertEqual(discovered, override)
+
+    def test_project_env_before_parent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "current"
+            project.mkdir()
+            project_env = project / ".env"
+            parent_env = Path(tmp) / ".env"
+            parent_env.write_text("PARENT=1")
+            project_env.write_text("PROJECT=1")
+
+            with mock.patch.dict(os.environ, {}, clear=True):
+                discovered = cli_main._discover_env_file(project)
+
+            self.assertEqual(discovered, project_env)
+
+    def test_none_when_no_env_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "current"
+            project.mkdir()
+
+            with mock.patch.dict(os.environ, {}, clear=True):
+                discovered = cli_main._discover_env_file(project)
+
+            self.assertIsNone(discovered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- simplify the systemd service to run the packaged module directly and wire the timer/CI workflow to use the shared .env and data/log directories
- harden runtime helpers so .env files are discovered automatically, logging and SQLite paths are created under configurable data roots, and provide a documented .env.example
- add regression tests for env and path discovery utilities and document the end-to-end deployment process in the README

## Testing
- python -m unittest discover tests